### PR TITLE
Infrastructure and Reliability Additions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# From .gitignore
+.idea/
+node_modules/
+config/config.json
+
+# Others
+.git
+.gitignore
+.DS_Store
+.dockerignore
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:4.6.1
+
+ENV LDAPJWT_BASE_DIR="/usr/src/app"
+EXPOSE 3000
+
+WORKDIR "${LDAPJWT_BASE_DIR}"
+
+# Load dependencies to optimize the build cache
+COPY package.json ./
+RUN npm install
+
+#Copy code
+COPY . ./
+
+CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# Example Docker Usage:
+#   docker build -t ldap-jwt .
+#   docker run -p 3000:3000 --rm -it -v "$(pwd)/config/config.test.json:/usr/src/app/config/config.json" ldap-jwt
+
 FROM node:6.9.2
 
 ENV LDAPJWT_BASE_DIR="/usr/src/app"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.6.1
+FROM node:6.9.2
 
 ENV LDAPJWT_BASE_DIR="/usr/src/app"
 EXPOSE 3000

--- a/config/config.test.json
+++ b/config/config.test.json
@@ -5,7 +5,8 @@
 		"searchBase": "dc=example,dc=com",
 		"searchFilter": "(uid={{username}})",
 		"timeout": 5000,
-		"connectTimeout": 10000
+		"connectTimeout": 10000,
+		"reconnect": true
 	},
 	"jwt": {
 		"secret": "test_secret"

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ app.post('/authenticate', function (req, res) {
 
 				console.log(err);
 
-				if (err.name === 'InvalidCredentialsError') {
+				if (err.name === 'InvalidCredentialsError' || err.name === 'NoSuchObjectError' || (typeof err === 'string' && err.match(/no such user/i)) ) {
 					res.status(401).send({ error: 'Wrong user or password'});
 				} else {
 					// ldapauth-fork or underlying connections may be in an unusable state.

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ var authenticate = function (username, password) {
 };
 
 app.post('/authenticate', function (req, res) {
-    if(req.body.username && req.body.password) {
-        authenticate(req.body.username, req.body.password)
+	if(req.body.username && req.body.password) {
+		authenticate(req.body.username, req.body.password)
 			.then(function(user) {
 				var expires = moment().add(2, 'days').valueOf();
 				var token = jwt.encode({
@@ -44,12 +44,29 @@ app.post('/authenticate', function (req, res) {
 				res.json({token: token, full_name: user.cn});
 			})
 			.catch(function (err) {
+				// Ldap reconnect config needs to be set to true to reliably
+				// land in this catch when the connection to the ldap server goes away.
+				// REF: https://github.com/vesse/node-ldapauth-fork/issues/23#issuecomment-154487871
+
 				console.log(err);
-				res.status(401).send({ error: 'Wrong user or password'});
+
+				if (err.name === 'InvalidCredentialsError') {
+					res.status(401).send({ error: 'Wrong user or password'});
+				} else {
+					// ldapauth-fork or underlying connections may be in an unusable state.
+					// Reconnect option does re-establish the connections, but will not
+					// re-bind. Create a new instance of LdapAuth.
+					// REF: https://github.com/vesse/node-ldapauth-fork/issues/23
+					// REF: https://github.com/mcavage/node-ldapjs/issues/318
+
+					res.status(500).send({ error: 'Unexpected Error'});
+					auth = new LdapAuth(settings.ldap);
+				}
+
 			});
-    } else {
-        res.status(400).send({error: 'No username or password supplied'});
-    }
+		} else {
+			res.status(400).send({error: 'No username or password supplied'});
+		}
 });
 
 app.post('/verify', function (req, res) {
@@ -78,6 +95,9 @@ app.post('/verify', function (req, res) {
 
 var port = (process.env.PORT || 3000);
 app.listen(port, function() {
-    console.log('Listening on port: ' + port);
-});
+	console.log('Listening on port: ' + port);
 
+	if (typeof settings.ldap.reconnect === 'undefined' || settings.ldap.reconnect === null || settings.ldap.reconnect === false) {
+		console.warn('WARN: This service may become unresponsive when ldap reconnect is not configured.')
+	}
+});

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ app.post('/authenticate', function (req, res) {
 
 				console.log(err);
 
-				if (err.name === 'InvalidCredentialsError' || err.name === 'NoSuchObjectError' || (typeof err === 'string' && err.match(/no such user/i)) ) {
+				if (err.name === 'InvalidCredentialsError' || (typeof err === 'string' && err.match(/no such user/i)) ) {
 					res.status(401).send({ error: 'Wrong user or password'});
 				} else {
 					// ldapauth-fork or underlying connections may be in an unusable state.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Lightweight node.js based web service that provides user authentication against LDAP server (Active Directory / Windows network) credentials and returns a JSON Web Token.",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
**Infrastructure:**
- Add `start` command for easy consumption by `node:6-onbuild` docker image.
- Add Dockerfile

**Reliability:**
- Default to using ldap reconnect option.
  - https://github.com/vesse/node-ldapauth-fork/issues/23#issuecomment-154487871
- Warn about consequences of not using reconnect option.
- Only return HTTP 401 on bad username or password.
- All other errors from LDAP authentication replace the LdapAuth instance with a new one
  - https://github.com/vesse/node-ldapauth-fork/issues/23
  - https://github.com/mcavage/node-ldapjs/issues/318
