### PR TITLE
Format expiration date properly (seconds instead of millis)

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ app.post('/verify', function (req, res) {
 		try {
 			var decoded = jwt.decode(token, app.get('jwtTokenSecret'));
 
-			if (decoded.exp <= Date.now()) {
+			if (decoded.exp <= moment().format("X")) {
 				res.status(400).send({ error: 'Access token has expired'});
 			} else {
 				res.json({

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ app.post('/authenticate', function (req, res) {
 	if(req.body.username && req.body.password) {
 		authenticate(req.body.username, req.body.password)
 			.then(function(user) {
-				var expires = moment().add(2, 'days').valueOf();
+				var expires = moment().add(2, 'days').format("X");
 				var token = jwt.encode({
 					exp: expires,
 					user_name: user.uid,


### PR DESCRIPTION
The current implementation generates a timestamp for the exp field in milliseconds instead of seconds, which makes the token never expire. The spec reads:

> A JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds. This is equivalent to the IEEE Std 1003.1, 2013 Edition [POSIX.1] definition "Seconds Since the Epoch", in which each day is accounted for by exactly 86400 seconds, other than that non-integer values can be represented. See RFC 3339 [RFC3339] for details regarding date/times in general and UTC in particular.

This patch corrects this.