### PR TITLE
Return full jwt with /verify endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Heavily based on the work of [gregfroese/ldapservice](https://github.com/gregfro
 
 ```json
 {
+  "exp":1495058246
   "user_name": "euler",
   "full_name": "Leonhard Euler",
   "mail": "euler@ldap.forumsys.com"

--- a/index.js
+++ b/index.js
@@ -78,11 +78,7 @@ app.post('/verify', function (req, res) {
 			if (decoded.exp <= parseInt(moment().format("X"))) {
 				res.status(400).send({ error: 'Access token has expired'});
 			} else {
-				res.json({
-					user_name: decoded.user_name,
-					full_name: decoded.full_name,
-					mail: decoded.mail
-				});
+				res.json(decoded);
 			}
 		} catch (err) {
 			res.status(500).send({ error: 'Access token could not be decoded'});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldap-jwt",
-  "version": "1.0.1-rc.1",
+  "version": "1.0.1",
   "description": "Lightweight node.js based web service that provides user authentication against LDAP server (Active Directory / Windows network) credentials and returns a JSON Web Token.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldap-jwt",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.1",
   "description": "Lightweight node.js based web service that provides user authentication against LDAP server (Active Directory / Windows network) credentials and returns a JSON Web Token.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Initially we just wanted the `exp` claim included so applications can integrate JWT expiration into their own session management logic.

To implement, I just return the whole jwt since there doesn't seem to be anything sensitive there. That is also the behavior of the Auth0 node.js implementation at https://github.com/auth0/node-jsonwebtoken/blob/master/verify.js

This was spurred by the progress/merge from #4

