### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #   docker build -t ldap-jwt .
 #   docker run -p 3000:3000 --rm -it -v "$(pwd)/config/config.test.json:/usr/src/app/config/config.json" ldap-jwt
 
-FROM node:6.9.2
+FROM node:10.14.2
 
 ENV LDAPJWT_BASE_DIR="/usr/src/app"
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cors": "2.7.1",
     "express": "4.13.4",
     "jwt-simple": "0.5.0",
-    "ldapauth-fork": "2.5.2",
+    "ldapauth-fork": "github:flywheel-io/node-ldapauth-fork#starttls",
     "moment": "2.21.0",
     "promise": "^7.1.1"
   }


### PR DESCRIPTION
Uses our fork of node-ldapauth which supports the starttls option.
See: https://github.com/vesse/node-ldapauth-fork/pull/70